### PR TITLE
fix bugs at split numbers:

### DIFF
--- a/active_learner.py
+++ b/active_learner.py
@@ -128,12 +128,12 @@ class ActiveLearner:
 										 os.path.join(self.datasets_path, 'vocabs0'),
 										 self.split_ll_numbers_to_digits, self.split_hl_numbers_to_digits)
 		if self.framework == Framework.TensorFlow:
-			os.system('python -m tfnmt.scripts.build_vocab --size 50000 --save_vocab {0} {1} {2} {3}'.format(
+			os.system('python -m tfnmt.scripts.build_vocab --split_digits --save_vocab {0} {1} {2} {3}'.format(
 				os.path.join(self.datasets_path, 'vocabs0.ll'),
 				os.path.join(self.datasets_path, 'train0.corpus.ll'),
 				os.path.join(self.datasets_path, 'validate0.corpus.ll'),
 				os.path.join(self.datasets_path, 'test0.corpus.ll')))
-			os.system('python -m tfnmt.scripts.build_vocab --size 50000 --save_vocab {0} {1} {2} {3}'.format(
+			os.system('python -m tfnmt.scripts.build_vocab --split_digits --save_vocab {0} {1} {2} {3}'.format(
 				os.path.join(self.datasets_path, 'vocabs0.hl'),
 				os.path.join(self.datasets_path, 'train0.corpus.hl'),
 				os.path.join(self.datasets_path, 'validate0.corpus.hl'),

--- a/digits_utils.py
+++ b/digits_utils.py
@@ -14,7 +14,7 @@ def merge_digits_to_numbers(line):
 			if len(number) > 0:
 				new_tokens += [number]
 				number = ''
-			if token != '|':
+			if token != 'NS':
 				new_tokens += [token]
 	if len(number) > 0:
 		new_tokens += [number]
@@ -30,7 +30,7 @@ def split_numbers_to_digits(tokens):
                 digits = ['-N'] + digits[1:]
             if i+1 < len(tokens):
                 if re.match('^\-?[0-9]+$', tokens[i+1]):
-                    digits += ['|']
+                    digits += ['NS']
             new_tokens += digits
         else:
             new_tokens += [token]

--- a/dynmt/prepare_data.py
+++ b/dynmt/prepare_data.py
@@ -15,7 +15,7 @@ def split_numbers_to_digits(tokens):
                 digits = ['-N'] + digits[1:]
             if i+1 < len(tokens):
                 if re.match('^\-?[0-9]+$', tokens[i+1]):
-                    digits += ['|']
+                    digits += ['NS']
             new_tokens += digits
         else:
             new_tokens += [token]

--- a/generate_vocabularies.py
+++ b/generate_vocabularies.py
@@ -14,7 +14,7 @@ def parse_vocabulary(path, split_numbers):
 def generate_vocabs(datasets, out, split_ll_numbers, split_hl_numbers):
 	vocab_hl = set()
 	vocab_ll = set()
-	initial_vocab = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-N', '|']
+	initial_vocab = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-N', 'NS']
 	if split_ll_numbers:
 		vocab_ll.update(initial_vocab)
 	if split_hl_numbers:

--- a/tfnmt/model_helper.py
+++ b/tfnmt/model_helper.py
@@ -59,7 +59,7 @@ def prepare_tmp_dataset(input, split_digits, filter_tokens=[]):
                             digits = ['-N'] + digits[1:]
                         if i + 1 < len(parts):
                             if re.match('^\-?[0-9]+$', parts[i + 1]):
-                                digits += ['|']
+                                digits += ['NS']
                         new_parts += digits
                     else:
                         new_parts += [p]

--- a/tfnmt/scripts/build_vocab.py
+++ b/tfnmt/scripts/build_vocab.py
@@ -31,12 +31,11 @@ def main():
   tokenizer = tokenizers.build_tokenizer(args)
 
   special_tokens = ["<unk>"]
-  if args.split_digits:
-      special_tokens += ['-N', '|'] + map(str, range(0, 10))
   if not args.without_sequence_tokens:
     special_tokens.append("<s>")
     special_tokens.append("</s>")
-
+  if args.split_digits:
+      special_tokens += ['-N', 'NS'] + map(str, range(0, 10))
   vocab = Vocab(special_tokens=special_tokens)
   for data_file in args.data:
     vocab.add_from_text(data_file, tokenizer=tokenizer, ignore_numbers=args.split_digits)

--- a/tfnmt/utils/vocab.py
+++ b/tfnmt/utils/vocab.py
@@ -54,7 +54,7 @@ class Vocab(object):
       for line in text:
         line = tf.compat.as_text(line.strip())
         if ignore_numbers:
-          line = re.sub(' \-?[0-9]+ ', ' ', line)
+            line = re.sub('(\-| |^)[0-9]+', '', line)
         if tokenizer:
           tokens = tokenizer.tokenize(line)
         else:


### PR DESCRIPTION
1. use "NS" (number separator) instead of "|"
2. change the order of inserting tokens into "special_tokens"
3. fix the regex to decrease vocabulary size